### PR TITLE
chore(repository): include configuration proposals

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+# Define your testing env vars here
+NODE_ENV=test

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,11 @@
  * https://jestjs.io/docs/configuration
  */
 
-module.exports = {
+import { pathsToModuleNameMapper } from 'ts-jest'
+import { compilerOptions } from './tsconfig.paths.json'
+const moduleNameMapper = pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/' })
+
+export default {
   // All imported modules in your tests should be mocked automatically
   // automock: false,
 
@@ -54,7 +58,7 @@ module.exports = {
   // forceCoverageMatch: [],
 
   // A path to a module which exports an async function that is triggered once before all test suites
-  // globalSetup: undefined,
+  globalSetup: '<rootDir>/jest.dotenv.config.ts',
 
   // A path to a module which exports an async function that is triggered once after all test suites
   // globalTeardown: undefined,
@@ -81,7 +85,7 @@ module.exports = {
   // ],
 
   // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  moduleNameMapper,
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
   // modulePathIgnorePatterns: [],

--- a/jest.dotenv.config.ts
+++ b/jest.dotenv.config.ts
@@ -1,0 +1,6 @@
+import { resolve } from 'path'
+import { config } from 'dotenv'
+
+module.exports = async () => {
+  config({ path: resolve(__dirname, './.env.test') })
+}

--- a/package.json
+++ b/package.json
@@ -16,10 +16,17 @@
     "test:watch": "npm test -- --watchAll",
     "lint": "eslint . --ext .ts",
     "lint:fix": "npm run lint -- --fix",
+    "lint:lockfile": "lockfile-lint --path package-lock.json --type npm --validate-https --allowed-hotst npm",
     "dependencies:purge": "rm -rf node_modules package-lock.json build && npm install",
     "docs:generate": "auto-changelog -p; rm -rf docs && typedoc lib/ --plugin typedoc-plugin-markdown --out docs && git add CHANGELOG.md",
     "docs:update": "npm run docs:generate && git commit -m \"📝 update docs\"",
-    "docs:generate:html": "auto-changelog -p; rm -rf docs-html && typedoc lib/ --plugin none --out docs-html && git add CHANGELOG.md"
+    "docs:generate:html": "auto-changelog -p; rm -rf docs-html && typedoc lib/ --plugin none --out docs-html && git add CHANGELOG.md",
+    "deps": "npm run deps:audit && npm run deps:sec-scan",
+    "deps:audit": "npm audit && npm outdated -l",
+    "deps:sec-scan": "npm run lint:lockfile",
+    "release:bug": "npm --no-git-tag-version version patch",
+    "release:feature": "npm --no-git-tag-version version minor",
+    "release:breaking_change": "npm --no-git-tag-version version major"
   },
   "repository": {
     "type": "git",
@@ -56,8 +63,10 @@
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",
     "auto-changelog": "^2.3.0",
+    "dotenv": "^16.0.1",
     "eslint": "^7.31.0",
     "jest": "^27.0.6",
+    "lockfile-lint": "^4.7.6",
     "ts-jest": "^27.0.4",
     "typedoc": "^0.21.4",
     "typedoc-plugin-markdown": "^3.10.4"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
+  "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es2020",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "target": "es2020", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
@@ -12,7 +13,7 @@
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "./build",                        /* Redirect output structure to the directory. */
+    "outDir": "./build", /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
@@ -21,9 +22,8 @@
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
+    "strict": true, /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
@@ -31,37 +31,41 @@
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
     /* Additional Checks */
     // "noUnusedLocals": true,                /* Report errors on unused locals. */
     // "noUnusedParameters": true,            /* Report errors on unused parameters. */
     // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
-
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-     "rootDirs": ["./lib", "./test"],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    "rootDirs": [
+      "./lib",
+      "./test"
+    ], /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
     // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
     // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-
     /* Advanced Options */
-    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true, /* Disallow inconsistently-cased references to the same file. */
+    "resolveJsonModule": true,
+    "importsNotUsedAsValues": "error"
   },
-  "exclude": ["build", "node_modules", "test"]
+  "exclude": [
+    "build",
+    "node_modules",
+    "test"
+  ]
 }

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "@example": [
+        "src/path/to/example"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
He añadido algunas propuestas de configuración que yo suelo emplear en mis repos.

## Configuraciones adicionales al `tsconfig.json`

He añadido estas dos propiedades de configuración para TypeScript:

- `resolveJsonModule` Permitirá importar contenido de archivos JSON dentro de archivos TypeScript.
- `importsNotUsedAsValues` En ocasiones, tenemos archivos en los que hemos definido tipos/interfaces junto con funciones pero a la hora de importar, en muchas ocasiones sólo importamos dichos tipos/interfaces y no los métodos. Con esta propiedad, nos obliga a escribir `import type { myType } from '@myModule'`. Esto le sirve al compilador de TypeScript para sólo traerse la definición del tipo/interfaz al archivo de destino. Si no lo pusiéramos, se traería todo el contenido del módulo, incluyendo los métodos no utilizados. ¿Y qué pasa con el tree shacking? Pues que se aplica a JavaScript, no al proceso de compilación de TypeScript. De ahí la necesidad de usar este tipo de configuraciones.

## Rutas relativas para TypeScript

Creando el archivo `tsconfig.paths.json` se pueden definir rutas relativas para ser usadas en el código.

Este tipo de rutas proporciona un mejor mantenimiento del código así como refactorizaciones más sencillas, dado que al mover archivos de lugar, sus importaciones no se ven afectadas y en el caso de que haya que actualizar la importación del archivo desplazado, sólo hay que modificar la nueva ruta en el `tsconfig.paths.json`, no en todos los archivos afectados.

Para que este archivo tenga efecto, es necesario meterlo en el `tsconfig.json`, mediante la propiedad `extedns`.

## Configuración de Jest para que funcione con rutas relativas

Para que Jest pueda funcionar con las rutas relativas empleadas en el `tsconfig.json`, tenemos que definir cada path relativo dentro del bloque `moduleNameMapper` del archivo de configuración de Jest.

Para que esto pueda realizarse de manera automática, he añadido una serie de configuraciones en el archivo `jest.config.ts`. Finalmente, para que esto tenga efecto, era necesario renombrar la extensión del archivo de `js` a `ts`.

## Configuración de Jest para que funcione con variables de entorno

Lo más habitual en estos casos es trabajar con `dotenv`. En este caso, la librería está instalada como librería de desarrollo porque en mi caso, las variables de entorno se las suelo pasar al servicio en el momento de ejecutarlo.

De este modo, he creado el archivo `jest.dotenv.config.ts` y configurado la propiedad `globalSetup` en el archivo `jest.config.ts`. Así, cada vez que se ejecute Jest, se cargarán las variables de entorno definidas en el archivo `.env.test`.

## Scripts en el package.json

He añadido los siguientes scripts:

- `lint:lockfile` Permite analizar la estructura del archivo `package.lock.json` para mejorar la seguridad y evitar posibles problemas por inyección de dependencias desde repositorios no fiables.
- `deps` Ejecuta un análisis de las dependencias del repositorio en busca de posibles actualizaciones o amenazas conocidas.
- `release:bug`, `release:feature` y `release:breaking_change` Permiten actualizar automáticamente las versiones del repositorio.